### PR TITLE
add port option in CachingModuleOptions with default value

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdnest",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/src/common/caching/caching.service.ts
+++ b/packages/common/src/common/caching/caching.service.ts
@@ -11,7 +11,7 @@ import { OriginLogger } from "../../utils/origin.logger";
 
 @Injectable()
 export class CachingService {
-  protected client = createClient(6379, this.options.url);
+  protected client = createClient(this.options.port, this.options.url);
   private asyncSet = promisify(this.client.set).bind(this.client);
   private asyncGet = promisify(this.client.get).bind(this.client);
   private asyncIncr = promisify(this.client.incr).bind(this.client);

--- a/packages/common/src/common/caching/entities/caching.module.options.ts
+++ b/packages/common/src/common/caching/entities/caching.module.options.ts
@@ -5,6 +5,8 @@ export class CachingModuleOptions {
 
   url: string = '';
 
+  port: number = 6379;
+
   poolLimit: number = 100;
 
   processTtl: number = 60;


### PR DESCRIPTION
# Description of the reasoning behind the pull request
Currently erdnest is not usable with a redis db that have different port that one hardcoded in `CachingService`.
# Proposed Changes
Add the port option in CachingModuleOptions with the default value that will make it backwards compatibility while it gives possibility to be changed if intended.