### PR TITLE
Removing private constraints for complexity.

### DIFF
--- a/packages/common/src/interceptors/complexity.interceptor.ts
+++ b/packages/common/src/interceptors/complexity.interceptor.ts
@@ -7,7 +7,7 @@ import { ComplexityUtils } from "../common/complexity/complexity.utils";
 
 @Injectable()
 export class ComplexityInterceptor implements NestInterceptor {
-  private readonly complexityThreshold: number = 10000;
+  complexityThreshold: number = 10000;
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();


### PR DESCRIPTION
Removing private constraints for pagination and complexity will allow us to server more than 10000 results through Elrond API hosted instance. Since complexityThreshold is currently private, we cannot override it. I would've opened a proper PR but I guess I will have to be a contributor first.